### PR TITLE
IL computes and fixes

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,3 +5,11 @@ build:
   tools:
     python: "3.11"
     
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# Defining the exact version will make sure things don't break
+sphinx<6

--- a/docs/source/illinois_computes.rst
+++ b/docs/source/illinois_computes.rst
@@ -1,0 +1,4 @@
+Illinois Computes
+======================
+
+Illinois Computes projects can be granted access to the Hydro system.  This page outlines that process for prospective users and projects.  

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -117,6 +117,7 @@ Hydro Documentation Table of Contents
    index
    quick_start_guide
    system_description
+   illinois_computes
    accessing_transferring_files
    programming_environments
    containers


### PR DESCRIPTION
Adds template page for Illinois computes. 

Also implements fixes that work around current nonsynch library probems in the readthedocs infrastructure, and also pin the sphinx version so that simultaneously, the search still works. 

