### PR TITLE
Adding link to Documentation Hub

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -20,3 +20,14 @@ body > div > nav > div > div.wy-side-nav-search > a:hover{
 #cookie-button:hover {
     color: #13294B;
 }
+
+
+/* making "System Documentation Hub" link visited color the same as unvisited */
+body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside > a:visited{
+    color: #2980b9 !important;
+}
+
+
+body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside{
+    text-align: right;
+}

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -4,7 +4,7 @@ $( document ).ready(function() {
   var hub_link = document.createElement("a");
   var hub_text = document.createTextNode("NCSA Documentation Hub");
   hub_link.appendChild(hub_text);
-  hub_link.setAttribute("href", "https://docs.ncsa.illinois.edu");
+  hub_link.setAttribute("href", "https://docs.ncsa.illinois.edu/");
 
   var separator = document.createTextNode(" | ");
 

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -12,7 +12,7 @@ $( document ).ready(function() {
   aside = document.querySelector("body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside > a");
 
   // Next to the default "Edit on GitHub", add a separator, then the hub link.
-  // aside.replaceWith(hub_link);
+  aside.replaceWith(hub_link);
 
 
 });

--- a/docs/source/_static/js/custom.js
+++ b/docs/source/_static/js/custom.js
@@ -1,0 +1,18 @@
+$( document ).ready(function() {
+
+  // Create link and text for navigation back to the documentation hub home page
+  var hub_link = document.createElement("a");
+  var hub_text = document.createTextNode("NCSA Documentation Hub");
+  hub_link.appendChild(hub_text);
+  hub_link.setAttribute("href", "https://docs.ncsa.illinois.edu");
+
+  var separator = document.createTextNode(" | ");
+
+  // This replaces the GitHub link in the upper-right with the "Documentation Hub" link
+  aside = document.querySelector("body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside > a");
+
+  // Next to the default "Edit on GitHub", add a separator, then the hub link.
+  // aside.replaceWith(hub_link);
+
+
+});

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,11 @@ html_css_files = [
     'css/custom.css',
 ]
 
+# -- custom JS
+html_js_files = [
+    'js/custom.js',
+]
+
 # -- Logo 
 html_static_path = ['_static']
 html_logo = "images/BlockI-NCSA-Full-Color-RGB_border4.png"


### PR DESCRIPTION
This PR replaces the 'Edit on GitHub' link in the upper-right corner with the 'NCSA Documentation Hub' link. You can still access the GitHub repo from any Read the Docs page by opening the 'Read the Docs' menu in the bottom left corner and clicking 'View' or 'Edit' under 'On GitHub'.

![image](https://github.com/ncsa/hydro_documentation/assets/141255627/906b9aa6-0a4e-4caa-81d5-95128353c438)
